### PR TITLE
RDKE-606: bluetooth thunder plugin coming up before bluetooth manager

### DIFF
--- a/systemd/system/wpeframework-bluetooth.service
+++ b/systemd/system/wpeframework-bluetooth.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Bluetooth Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework.service iarmbusd.service btmgr.service
+After=wpeframework.service iarmbusd.service btmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
wpeframework bluetooth service can't come up until btmgr is up