### PR TITLE
RDK-52212: RDK-E - Update IARM Power Manager clients with new Plugin

### DIFF
--- a/systemd/system/wpeframework-powermanager.service
+++ b/systemd/system/wpeframework-powermanager.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=WPEFramework PowerManager Initialiser
+Requires=wpeframework.service iarmbusd.service pwrmgr.service
+After=wpeframework.service iarmbusd.service pwrmgr.service 
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/PluginActivator org.rdk.PowerManager
+[Install]
+WantedBy=sky.service


### PR DESCRIPTION
RDK-52212: RDK-E - Updated the startup for the Power Manager Plugin

Reason for change: Activate the power manager plugin on bootup
Reason for change: curl command to verify the activate status