### PR TITLE
RDK-52212: RDK-E - Update IARM Power Manager clients with new Plugin

### DIFF
--- a/systemd/system/wpeframework-frontpanel.service
+++ b/systemd/system/wpeframework-frontpanel.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework FrontPanel Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
+Requires=wpeframework-powermanager.service dsmgr.service
+After=wpeframework-powermanager.service dsmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-hdcpprofile.service
+++ b/systemd/system/wpeframework-hdcpprofile.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework HdcpProfile Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service
+Requires=wpeframework-powermanager.service dsmgr.service
+After=wpeframework-powermanager.service dsmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-hdmicecsink.service
+++ b/systemd/system/wpeframework-hdmicecsink.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework HdmiCecSink Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
+Requires=dsmgr.service wpeframework-powermanager.service
+After=dsmgr.service wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-hdmicecsource.service
+++ b/systemd/system/wpeframework-hdmicecsource.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework HdmiCecSource Initialiser
 Requires=wpeframework.service
-After=wpeframework.service iarmbusd.service dsmgr.service
+After=wpeframework-powermanager.service dsmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-system.service
+++ b/systemd/system/wpeframework-system.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework System Initialiser
-Requires=wpeframework.service iarmbusd.service sysmgr.service mfrmgr.service pwrmgr.service 
-After=wpeframework.service iarmbusd.service sysmgr.service mfrmgr.service pwrmgr.service 
+Requires=wpeframework-telemetry.service sysmgr.service mfrmgr.service
+After=wpeframework-telemetry.service sysmgr.service mfrmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-telemetry.service
+++ b/systemd/system/wpeframework-telemetry.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Telemetry Initialiser
-Requires=wpeframework.service iarmbusd.service
-After=wpeframework.service iarmbusd.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-xcast.service
+++ b/systemd/system/wpeframework-xcast.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Xcast Initialiser
-Requires=wpeframework.service iarmbusd.service pwrmgr.service
-After=wpeframework.service iarmbusd.service pwrmgr.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
RDK-52212: RDK-E - Updated the startup for the Power Manager Plugin

Reason for change: Activate the power manager plugin on bootup
Reason for change: curl command to verify the activate status