### PR TITLE
RDK-53904: Auto start up error with USB Device

### DIFF
--- a/systemd/system/wpeframework-usbdevice.service
+++ b/systemd/system/wpeframework-usbdevice.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=WPEFramework USBDevice Initialiser
+Description=WPEFramework UsbDevice Initialiser
 Requires=wpeframework.service
 After=wpeframework.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/PluginActivator org.rdk.USBDevice
+ExecStart=/usr/bin/PluginActivator org.rdk.UsbDevice


### PR DESCRIPTION
Reason for change: Updated UsbDevice callsign in startup services.
Test Procedure: Make full stack build and verify UsbDevice is activating on bootup or not.
Risks: Low
Priority: P1