### PR TITLE
RDKEMW-1766: getDevicePowerState is failing, causing EPG not to start (Stuck at Sky)

### DIFF
--- a/systemd/system/wpeframework-bluetooth.service
+++ b/systemd/system/wpeframework-bluetooth.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Bluetooth Initialiser
-Requires=wpeframework.service iarmbusd.service btmgr.service
-After=wpeframework.service iarmbusd.service btmgr.service
+Requires=wpeframework-powermanager.service iarmbusd.service btmgr.service
+After=wpeframework-powermanager.service iarmbusd.service btmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-cloudstore.service
+++ b/systemd/system/wpeframework-cloudstore.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework CloudStore Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-displayinfo.service
+++ b/systemd/system/wpeframework-displayinfo.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework DisplayInfo Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service
+Requires=wpeframework-powermanager.service iarmbusd.service dsmgr.service
+After=wpeframework-powermanager.service iarmbusd.service dsmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-displaysettings.service
+++ b/systemd/system/wpeframework-displaysettings.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework DisplaySettings Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service pwrmgr.service
+Requires=dsmgr.service wpeframework-powermanager.service
+After=dsmgr.service wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-firmwareupdate.service
+++ b/systemd/system/wpeframework-firmwareupdate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework FirmwareUpdate Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-persistentstore.service
+++ b/systemd/system/wpeframework-persistentstore.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework PersistentStore Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-playerinfo.service
+++ b/systemd/system/wpeframework-playerinfo.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework PlayerInfo Initialiser
-Requires=wpeframework.service iarmbusd.service dsmgr.service
-After=wpeframework.service iarmbusd.service dsmgr.service
+Requires=wpeframework-powermanager.service iarmbusd.service dsmgr.service
+After=wpeframework-powermanager.service iarmbusd.service dsmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-powermanager.service
+++ b/systemd/system/wpeframework-powermanager.service
@@ -7,4 +7,4 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/PluginActivator org.rdk.PowerManager
 [Install]
-WantedBy=sky.service
+WantedBy=multi-user.target

--- a/systemd/system/wpeframework-remotecontrol.service
+++ b/systemd/system/wpeframework-remotecontrol.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework RemoteControl Initialiser
-Requires=wpeframework.service iarmbusd.service ctrlm-main.service
-After=wpeframework.service iarmbusd.service ctrlm-main.service
+Requires=wpeframework-powermanager.service iarmbusd.service ctrlm-main.service
+After=wpeframework-powermanager.service iarmbusd.service ctrlm-main.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-system.service
+++ b/systemd/system/wpeframework-system.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework System Initialiser
-Requires=wpeframework-telemetry.service sysmgr.service mfrmgr.service
-After=wpeframework-telemetry.service sysmgr.service mfrmgr.service
+Requires=wpeframework-powermanager.service sysmgr.service mfrmgr.service
+After=wpeframework-powermanager.service sysmgr.service mfrmgr.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-systemaudioplayer.service
+++ b/systemd/system/wpeframework-systemaudioplayer.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework SystemAudioPlayer Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-systemmode.service
+++ b/systemd/system/wpeframework-systemmode.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework SystemMode Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-telemetry.service
+++ b/systemd/system/wpeframework-telemetry.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Telemetry Initialiser
-Requires=wpeframework-powermanager.service
-After=wpeframework-powermanager.service
+Requires=wpeframework-system.service wpeframework-powermanager.service
+After=wpeframework-system.service wpeframework-powermanager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/systemd/system/wpeframework-voicecontrol.service
+++ b/systemd/system/wpeframework-voicecontrol.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework VoiceControl Initialiser
-Requires=wpeframework.service iarmbusd.service ctrlm-main.service
-After=wpeframework.service iarmbusd.service ctrlm-main.service
+Requires=wpeframework-powermanager.service iarmbusd.service ctrlm-main.service
+After=wpeframework-powermanager.service iarmbusd.service ctrlm-main.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
RDKEMW-1766: [XIONEUK] getDevicePowerState is failing, causing EPG not to start (Stuck at Sky)

Reason for change: The PowerManager Interface get failed because the client plugin started earlier
Test Procedure: Validate the plugin interface full stack build