### PR TITLE
RDKEMW-2952 : Failed to start wpeframework-ocdm

### DIFF
--- a/systemd/system/wpeframework-ocdm.service
+++ b/systemd/system/wpeframework-ocdm.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework OCDM Initialiser
-Requires=wpeframework.service wpeframework-deviceprovisioning.service
-After=wpeframework.service wpeframework-deviceprovisioning.service
+Requires=wpeframework.service
+After=wpeframework.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
Reason for change: Move deviceprovisioning dependancy to comcast layer

Test Procedure: Build and verify.

Risks: low