### PR TITLE
RDKEMW-3311 - NetworkManager Thunder Plugin - Systemd Service cleanup

### DIFF
--- a/systemd/system/wpeframework-networkmanager.service
+++ b/systemd/system/wpeframework-networkmanager.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=WPEFramework NetworkManager Initialiser
+Requires=wpeframework.service iarmbusd.service NetworkManager.service
+After=wpeframework.service iarmbusd.service NetworkManager.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/PluginActivator org.rdk.NetworkManager


### PR DESCRIPTION
Reason for change: Moved the wpeframework-networkmanager.service from meta-rdk-comcast-video to here
Test Procedure: check the command "systemctl status NetworkManager"
Risks: Medium
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>