### PR TITLE
RDKEMW-3387: thunder-startup-services - fixed wpeframework-ocdm.servi…

### DIFF
--- a/systemd/system/wpeframework-ocdm.service
+++ b/systemd/system/wpeframework-ocdm.service
@@ -1,9 +1,13 @@
 [Unit]
-Description=WPEFramework OCDM Initialiser
+Description=WPEFramework OCDM Plugin
 Requires=wpeframework.service
 After=wpeframework.service
 ConditionPathExists=/tmp/wpeframeworkstarted
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/PluginActivator -r 200 OCDM
+ExecStart=/usr/bin/PluginActivator org.rdk.OCDM
+
+[Install]
+WantedBy=wpeframework-provisioning-ready.path

--- a/systemd/system/wpeframework-provisioning-ready.path
+++ b/systemd/system/wpeframework-provisioning-ready.path
@@ -1,0 +1,11 @@
+[Unit]
+Description=Wait for Thunder PROVISIONING precondition
+Documentation=Thunder framework provisioning precondition fulfilled
+After=wpeframework-deviceprovisioning.service
+
+[Path]
+PathExists=/tmp/thunder-provisioning-precondition
+MakeDirectory=false
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
…ce failed state

Reason for change:
- OCDM fails w/o DRM (fail fast policy)
- wpeframework-ocdm.service starts w/o DRM because it is a systemd service which is not aware when device is provisioned
- This makes OCDM fail Resolution: New systemd unit wpeframework-provisioning-ready.path allows OCDM to start timely

Test Procedure: described in the ticket
Implements: code changes in DeviceProvisioning and Thunder Startup Services
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending