### PR TITLE
RDKEMW-3659: Fix WPE_ERROR_ResourceUnavail message on getModel

### DIFF
--- a/systemd/system/wpeframework-system.service
+++ b/systemd/system/wpeframework-system.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework System Initialiser
-Requires=wpeframework-powermanager.service sysmgr.service mfrmgr.service
-After=wpeframework-powermanager.service sysmgr.service mfrmgr.service
+Requires=wpeframework-powermanager.service sysmgr.service mfrmgr.service wpeframework-deviceinfo.service
+After=wpeframework-powermanager.service sysmgr.service mfrmgr.service wpeframework-deviceinfo.service
 ConditionPathExists=/tmp/wpeframeworkstarted
 [Service]
 Type=oneshot


### PR DESCRIPTION
Reason for change: Fix WPE_ERROR_ResourceUnavail message on getModel
Test Procedure: Refer ticket
Risks: Low

Signed-off-by: Deepak_Ponnath2@comcast.com