### PR TITLE
RDKEMW-8122 : Stability testing of thunder restart

### DIFF
--- a/systemd/system/wpeframework-services.target
+++ b/systemd/system/wpeframework-services.target
@@ -5,3 +5,7 @@
 Description=Target for WPEFramework-related services
 Requires=
 After=wpeframework.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'if [ -f /opt/restartEPG.sh ]; then /bin/sh /opt/restartEPG.sh; fi'


### PR DESCRIPTION
Reason for change: Stability
Test Procedure: Boot the TV.
Risks: low