### PR TITLE
RDKEMW-7962 Device goes to standby after restarting wpeframework

### DIFF
--- a/systemd/system/wpeframework-powermanager.service
+++ b/systemd/system/wpeframework-powermanager.service
@@ -7,5 +7,6 @@ ConditionPathExists=/tmp/wpeframeworkstarted
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/PluginActivator org.rdk.PowerManager
+ExecStop=/bin/touch /tmp/pwrmgr_restarted
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The PowerManager service was modified to create the /tmp/pwrmgr_restarted file after startup, ensuring that the device remains in the active state after a WPEFramework restart.