### PR TITLE
RDKEMW-10148 : wpeframework-bluetooth.service is not running after DE…

### DIFF
--- a/systemd/system/wpeframework-bluetooth.service
+++ b/systemd/system/wpeframework-bluetooth.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=WPEFramework Bluetooth Initialiser
-Requires=wpeframework-powermanager.service iarmbusd.service btmgr.service
+Requires=wpeframework-powermanager.service iarmbusd.service bluetooth.service
 After=wpeframework-powermanager.service iarmbusd.service btmgr.service
 ConditionPathExists=/tmp/wpeframeworkstarted
 [Service]


### PR DESCRIPTION
Reason for change:
To prevent the current service from shutting down during DEEPSLEEP when btmgr.service stops, by switching the dependency to bluetooth.service which remains active.

Risks: Medium
Priority: P1