### PR TITLE
RDKEMW-11468 : Make xcast to start after deviceInfo for serial number query

### DIFF
--- a/systemd/system/wpeframework-xcast.service
+++ b/systemd/system/wpeframework-xcast.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Xcast Initialiser
 Requires=wpeframework-powermanager.service
-After=wpeframework-powermanager.service
+After=wpeframework-powermanager.service wpeframework-deviceinfo.service
 ConditionPathExists=/tmp/wpeframeworkstarted
 [Service]
 Type=oneshot


### PR DESCRIPTION
ReasonForChange: XCast plugin shall be querying DeviceInfo.serialnumber for generating UUID as a fallback when AuthService is not available.