### PR TITLE
RDKEMW-13574: Device goes to standby after restarting wpeframework

### DIFF
--- a/systemd/system/wpeframework-powermanager.service
+++ b/systemd/system/wpeframework-powermanager.service
@@ -7,5 +7,6 @@ ConditionPathExists=/tmp/wpeframeworkstarted
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/PluginActivator org.rdk.PowerManager
+ExecStop=/bin/touch /tmp/pwrmgr_restarted
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
RDKEMW-13574: Device goes to standby after restarting wpeframework

Reason for change: '/tmp/pwrmgr_restarted' need to created by PowerManager service while service stop. So that PowerManager plugin doesnot force to STANDBY if  '/tmp/pwrmgr_restarted' is present

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]