### PR TITLE
RDKEMW-21510: Order Cryptography activation after PowerManager

### DIFF
--- a/systemd/system/wpeframework-cryptography.service
+++ b/systemd/system/wpeframework-cryptography.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=WPEFramework Cryptography Initialiser
-Requires=wpeframework.service
-After=wpeframework.service
+Requires=wpeframework-powermanager.service
+After=wpeframework-powermanager.service
 ConditionPathExists=/tmp/wpeframeworkstarted
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Reason for change

Backport of rdkcentral/thunder-startup-services#240 (RDKEMW-19048) onto `support/8.4.4.0`.

The Cryptography plugin registers an `IPowerManager` mode-change handler in `CryptographyExtAccess::Initialize()` with no retry on failure. If `org.rdk.PowerManager` is not active when `org.rdk.Cryptography` initializes, the registration fails silently and the deep-sleep SecAPI handle release never fires (RDKEMW-13788).

Requires and orders `wpeframework-cryptography.service` after `wpeframework-powermanager.service`; `wpeframework.service` stays required transitively.

## Test Procedure

Described in the ticket: standby/wake with Network Standby OFF; confirm `org.rdk.Cryptography` activates after `org.rdk.PowerManager` and the handler registration succeeds in the logs.

## Risks

Low
